### PR TITLE
feat(): Add demo to config template & avoid some code if demo mode is true

### DIFF
--- a/deployment/gar-connector/conf.json.template
+++ b/deployment/gar-connector/conf.json.template
@@ -20,6 +20,7 @@
     "export-archive-path": "${garExportPath}data-compress/",
     "export-cron": "${garExportCron}",
     "id-ent" : "${garIdENT}",
+    "demo": "${garDemo}"
     "control-group" : "RESP-AFFECT-GAR",
     "academy-prefix": "${academyPrefix}",
     "gar-ressources" : {

--- a/src/main/java/fr/openent/gar/Gar.java
+++ b/src/main/java/fr/openent/gar/Gar.java
@@ -17,7 +17,7 @@ public class Gar extends BaseServer {
 
 	public static final String GAR_ADDRESS = "openent.mediacentre";
 	public static boolean demo;
-	public static JsonObject CONFIG;
+	public static JsonObject config;
 	public final static String AAF = "AAF";
 	public final static String AAF1D = "AAF1D";
 
@@ -25,6 +25,8 @@ public class Gar extends BaseServer {
 	public void start() throws Exception {
 		super.start();
 		final EventBus eb = getEventBus(vertx);
+
+		demo = config.getBoolean("demo", false);
 
 		final String host = config.getString("host").split("//")[1];
 
@@ -44,7 +46,8 @@ public class Gar extends BaseServer {
 		}
 
 		final JsonObject garRessources = config.getJsonObject("gar-ressources", new JsonObject());
-		if (garRessources.containsKey("cert") || garRessources.containsKey("key")) {
+		if ((garRessources.containsKey("cert") && !garRessources.getString("cert").isEmpty()) ||
+				(garRessources.containsKey("key") && !garRessources.getString("key").isEmpty())) {
 			garRessources.put("domains", new JsonObject().put(host,
 					new JsonObject().put("cert", garRessources.getString("cert")).put("key", garRessources.getString("key"))));
 			garRessources.remove("cert");
@@ -69,8 +72,6 @@ public class Gar extends BaseServer {
 		addController(new SettingController(eb));
 
 		final String exportCron = config.getString("export-cron", "");
-		demo = config.getBoolean("demo", false);
-		CONFIG = config;
 
 		vertx.deployVerticle("fr.openent.gar.export.impl.ExportWorker", new DeploymentOptions().setConfig(config)
 				.setIsolationGroup("mediacentre_worker_group")

--- a/src/main/java/fr/openent/gar/export/impl/ExportImpl.java
+++ b/src/main/java/fr/openent/gar/export/impl/ExportImpl.java
@@ -1,6 +1,7 @@
 package fr.openent.gar.export.impl;
 
 import fr.openent.gar.Gar;
+import static fr.openent.gar.Gar.config;
 import fr.openent.gar.constants.GarConstants;
 import fr.openent.gar.export.ExportService;
 import fr.openent.gar.export.XMLValidationHandler;
@@ -35,7 +36,6 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 
-import static fr.openent.gar.Gar.CONFIG;
 import static fr.wseduc.webutils.Utils.handlerToAsyncHandler;
 
 public class ExportImpl {
@@ -45,18 +45,16 @@ public class ExportImpl {
     private TarService tarService;
     private JsonObject sftpGarConfig;
     private EventBus eb;
-    private final JsonObject config;
     private Vertx vertx;
     private final EmailSender emailSender;
 
     public ExportImpl(Vertx vertx, String entId, String source, Handler<String> handler) {
         this.vertx = vertx;
-        this.config = CONFIG;
         this.eb = vertx.eventBus();
         this.exportService = new ExportServiceImpl(config);
         this.tarService = new DefaultTarService();
         this.sftpGarConfig = config.getJsonObject("gar-sftp");
-        this.emailSender = new EmailFactory(vertx,this.config).getSender();
+        this.emailSender = new EmailFactory(vertx, config).getSender();
         if (Gar.AAF1D.equals(source)) {
             this.exportAndSend1d(entId, source, handler);
         } else {
@@ -65,8 +63,7 @@ public class ExportImpl {
     }
 
     public ExportImpl(Vertx vertx) {
-        this.config = CONFIG;
-        this.emailSender = new EmailFactory(vertx,this.config).getSender();
+        this.emailSender = new EmailFactory(vertx, config).getSender();
     }
 
     private void exportAndSend1d(final String entId, final String source, final Handler<String> handler) {

--- a/src/main/java/fr/openent/gar/helper/impl/PaginatorHelperImpl.java
+++ b/src/main/java/fr/openent/gar/helper/impl/PaginatorHelperImpl.java
@@ -7,7 +7,7 @@ import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import org.entcore.common.neo4j.Neo4j;
 
-import static fr.openent.gar.Gar.CONFIG;
+import static fr.openent.gar.Gar.config;
 import static org.entcore.common.neo4j.Neo4jResult.validResult;
 
 public class PaginatorHelperImpl implements PaginatorHelper  {
@@ -17,8 +17,8 @@ public class PaginatorHelperImpl implements PaginatorHelper  {
 
     public PaginatorHelperImpl() {
         LIMIT = 25000;
-        if(CONFIG.containsKey("pagination-limit")){
-            LIMIT = CONFIG.getInteger("pagination-limit");
+        if(config.containsKey("pagination-limit")){
+            LIMIT = config.getInteger("pagination-limit");
         }
     }
 

--- a/src/main/java/fr/openent/gar/service/impl/DefaultResourceService.java
+++ b/src/main/java/fr/openent/gar/service/impl/DefaultResourceService.java
@@ -26,9 +26,8 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.Map;
+import java.util.*;
+import java.util.stream.Collectors;
 import java.util.zip.GZIPInputStream;
 
 public class DefaultResourceService implements ResourceService {
@@ -53,13 +52,15 @@ public class DefaultResourceService implements ResourceService {
 
         final JsonObject domains =  garRessource.getJsonObject("domains", new JsonObject());
 
-        for (String domain : domains.fieldNames()) {
-            final JsonObject res = domains.getJsonObject(domain);
-            if (res == null) continue;
-            try {
-                httpClientByDomain.put(domain, generateHttpClient(new URI(garHost), res.getString("cert"), res.getString("key")));
-            } catch (URISyntaxException e) {
-                log.error("[DefaultResourceService@constructor] An error occurred when creating the URI", e);
+        if (!Gar.demo) {
+            List<String> fieldNames = domains.fieldNames().stream().filter(Objects::nonNull).collect(Collectors.toList());
+            for (String fieldName : fieldNames) {
+                final JsonObject domain = domains.getJsonObject(fieldName);
+                try {
+                    httpClientByDomain.put(fieldName, generateHttpClient(new URI(garHost), domain.getString("cert"), domain.getString("key")));
+                } catch (URISyntaxException e) {
+                    log.error("[DefaultResourceService@constructor] An error occurred when creating the URI : " + e);
+                }
             }
         }
     }


### PR DESCRIPTION
## Describe your changes

- Adds "demo" property to conf.json.template (was already used as conf but not present in template).
- Skips creation of httpClients for each domain when demo mode is activated. Indeed, in demo mode we display "fake" cards based on raw data directly written in a java file. We do not need to get data from the differents domains (GAR, PMB, ...)

## Checklist tests

## Issue ticket number and link

## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [ ] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)